### PR TITLE
Use a path under the user's home directory for the log

### DIFF
--- a/groupme.cabal
+++ b/groupme.cabal
@@ -34,5 +34,7 @@ executable groupme
                        shelly,
                        cmdargs,
                        HTTP,
-                       http-conduit
+                       http-conduit,
+                       directory,
+                       filepath
   ghc-options: -threaded -rtsopts

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -12,11 +12,13 @@ import Data.Maybe
 import Control.Applicative
 import GroupMe.Utils
 import Control.Concurrent
-import Shelly
+import Shelly hiding (FilePath)
 import System.Environment
 import System.Console.CmdArgs
 import Data.IORef
 import System.IO
+import System.Directory
+import System.FilePath
 
 data Args = Args { token :: String, user_id :: Int, group_id :: Int, list_groups :: Bool, about_me :: Bool, notification :: String, debug :: Bool } deriving (Show, Data, Typeable)
 
@@ -45,7 +47,8 @@ notifyAndPrint notifyMe msg = do
           return ()
     putStrLn . highlightPushMsg notifyMe $ msg
     hFlush stdout
-    appendFile "/root/chatlog" ((maybe "" id (pmsgUserName msg)) ++ ": " ++ (maybe "" id (pmsgText msg)) ++ "\n")
+    appDir <- getAppUserDataDirectory "groupme-cli"
+    appendFile (joinPath [appDir, "/chatlog"]) ((maybe "" id (pmsgUserName msg)) ++ ": " ++ (maybe "" id (pmsgText msg)) ++ "\n")
 
 printGroups tok = do
     grps <- groups tok


### PR DESCRIPTION
First, I don't know Haskell, so this may be the wrong way to fix the issue, or there may be a better way of doing things.

This gets a directory where user files can be stored and adds the chatlog file there. For example, on Linux it should be `/home/user/.groupme-cli/chatlog`. I haven't been able to trigger a write to the chatlog. I guess it seems to only happen if you receive a message when you are connected using groupme-cli, because connecting after a new message is received doesn't trigger a write to the chatlog for me. So this should be tested before merging.
